### PR TITLE
Make high-scale-lib a proper OSGi bundle

### DIFF
--- a/high-scale-lib/pom.xml
+++ b/high-scale-lib/pom.xml
@@ -13,8 +13,38 @@
     <version>1.1.5-SNAPSHOT</version>
   </parent>
   <artifactId>high-scale-lib</artifactId>
+  <packaging>bundle</packaging>
 
   <name>Highly Scalable Java</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <inherited>true</inherited>
+        <configuration>
+          <instructions>
+            <Bundle-Name>${project.name}</Bundle-Name>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>org.cliffc.high_scale_lib;version="${project.version}"</Export-Package>
+            <Import-Package>!org.cliffc.high_scale_lib,com,sun*</Import-Package>
+          </instructions>
+          <unpackBundle>true</unpackBundle>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.10</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.6</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
In order to use high-scale-lib inside OSGi proper OSGi MANIFEST.MF is required.

I used to maven-bundle-plugin to generate one.
