### PR TITLE
Make AtomicReferenceFieldUpdater declarations static

### DIFF
--- a/high-scale-lib/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashMap.java
+++ b/high-scale-lib/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashMap.java
@@ -734,7 +734,7 @@ public class NonBlockingHashMap<TypeK, TypeV>
     // to get the required memory orderings.  It monotonically transits from
     // null to set (once).
     volatile Object[] _newkvs;
-    private final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
+    private static final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
       AtomicReferenceFieldUpdater.newUpdater(CHM.class,Object[].class, "_newkvs");
     // Set the _next field if we can.
     boolean CAS_newkvs( Object[] newkvs ) {

--- a/high-scale-lib/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashtable.java
+++ b/high-scale-lib/src/main/java/org/cliffc/high_scale_lib/NonBlockingHashtable.java
@@ -727,7 +727,7 @@ public class NonBlockingHashtable<TypeK, TypeV>
     // to get the required memory orderings.  It monotonically transits from
     // null to set (once).
     volatile Object[] _newkvs;
-    private final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
+    private static final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
       AtomicReferenceFieldUpdater.newUpdater(CHM.class,Object[].class, "_newkvs");
     // Set the _next field if we can.
     boolean CAS_newkvs( Object[] newkvs ) {

--- a/high-scale-lib/src/main/java/org/cliffc/high_scale_lib/NonBlockingIdentityHashMap.java
+++ b/high-scale-lib/src/main/java/org/cliffc/high_scale_lib/NonBlockingIdentityHashMap.java
@@ -701,7 +701,7 @@ public class NonBlockingIdentityHashMap<TypeK, TypeV>
     // to get the required memory orderings.  It monotonically transits from
     // null to set (once).
     volatile Object[] _newkvs;
-    private final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
+    private static final AtomicReferenceFieldUpdater<CHM,Object[]> _newkvsUpdater =
       AtomicReferenceFieldUpdater.newUpdater(CHM.class,Object[].class, "_newkvs");
     // Set the _next field if we can.
     boolean CAS_newkvs( Object[] newkvs ) {


### PR DESCRIPTION
The Map implementations each have an AtomicReferenceFieldUpdater that is declared as an instance variable - this causes unnecessary, and expensive, work to happen on every instantiation rather than only once at static initialisation.